### PR TITLE
TorchText embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ word is not correctly spelt then will be replaced by an empty string.
 Applies on the token level, converting words by embeddings
 
 - `GensimEmbeddings`: Use Gensim word embeddings.
-- `TorchTextEmbeddings`: Use Torchtext word embeddings.
+- `TorchTextEmbeddings`: Applies word embeddings using torchtext models `Glove`, `CharNGram` and `FastText`.
 
 #### Document
 `Document` is a dataclass that contains all the information used during text preprocessing.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ word is not correctly spelt then will be replaced by an empty string.
 Applies on the token level, converting words by embeddings
 
 - `GensimEmbeddings`: Use Gensim word embeddings.
+- `TorchTextEmbeddings`: Use Torchtext word embeddings.
 
 #### Document
 `Document` is a dataclass that contains all the information used during text preprocessing.

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -34,20 +34,20 @@ class GensimEmbeddings(BaseTransformer):
     Returns: Document
 
     Example:
-        import gensim.downloader
+        >>> import gensim.downloader
 
-        from nlpiper.transformers.embeddings import GensimEmbeddings
-        from nlpiper.core.document import Document
-        from nlpiper.transformers.tokenizers import BasicTokenizer
+        >>> from nlpiper.transformers.embeddings import GensimEmbeddings
+        >>> from nlpiper.core.document import Document
+        >>> from nlpiper.transformers.tokenizers import BasicTokenizer
 
-        glove_vectors = gensim.downloader.load('glove-twitter-25')
-        doc = Document('Test random stuff.')
+        >>> glove_vectors = gensim.downloader.load('glove-twitter-25')
+        >>> doc = Document('Test random stuff.')
 
-        t = BasicTokenizer()
-        t(doc, inplace=True)
+        >>> t = BasicTokenizer()
+        >>> t(doc, inplace=True)
 
-        e = GensimEmbeddings(glove_vectors, True)
-        e(doc)
+        >>> e = GensimEmbeddings(glove_vectors, True)
+        >>> e(doc)
 
     """
 
@@ -125,20 +125,20 @@ class TorchTextEmbeddings(BaseTransformer):
 
      Example:
 
-        from torchtext.vocab import CharNGram
+        >>> from torchtext.vocab import CharNGram
 
-        from nlpiper.transformers.embeddings import TorchTextEmbeddings
-        from nlpiper.core.document import Document
-        from nlpiper.transformers.tokenizers import BasicTokenizer
+        >>> from nlpiper.transformers.embeddings import TorchTextEmbeddings
+        >>> from nlpiper.core.document import Document
+        >>> from nlpiper.transformers.tokenizers import BasicTokenizer
 
-        doc = Document('Test random stuff.')
+        >>> doc = Document('Test random stuff.')
 
-        t = BasicTokenizer()
-        t(doc, inplace=True)
+        >>> t = BasicTokenizer()
+        >>> t(doc, inplace=True)
 
-        model = CharNGram()
-        e = TorchTextEmbeddings(model, True)
-        e(doc)
+        >>> model = CharNGram()
+        >>> e = TorchTextEmbeddings(model, True)
+        >>> e(doc)
 
     """
 

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -190,9 +190,12 @@ class TorchTextEmbeddings(BaseTransformer):
         d = doc if inplace else doc._deepcopy()
 
         for token in d.tokens:
-
-            token.embedded = self.model.get_vecs_by_tokens(
-                token.cleaned).reshape(-1).to('cpu').detach().numpy()
+            token.embedded = self.model \ 
+                .get_vecs_by_tokens(token.cleaned) \
+                .reshape(-1) \ 
+                .to('cpu') \ 
+                .detach() \ 
+                .numpy()
 
         d.embedded = (getattr(self.np, self.apply_doc)([token.embedded for token in d.tokens], axis=0)
                       if len(d.tokens) != 0 else self.np.zeros(self.model.dim))

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -1,6 +1,9 @@
 """Embeddings Module."""
 
-from typing import Any, Optional
+from typing import (
+    Any,
+    Optional
+)
 
 from nlpiper.core.document import Document
 from nlpiper.transformers.base import (
@@ -12,23 +15,49 @@ from nlpiper.transformers.base import (
 from nlpiper.logger import log
 
 __all__ = [
-    "GensimEmbeddings"
+    "GensimEmbeddings",
+    "TorchTextEmbeddings"
 ]
 
 
 class GensimEmbeddings(BaseTransformer):
-    """Gensim Embedding extraction."""
+    """Gensim Embedding extraction.
+
+    Callable arguments:
+
+    Args:
+            keyed_vectors (Any): Gensim model based on keyedVectors,
+                see more in: https://radimrehurek.com/gensim/models/keyedvectors.html
+            apply_doc (str): Mode to calculate the embeddings vector for the document,
+                which could be `"mean"` or `"sum"` of the tokens.
+
+    Returns: Document
+
+    Example:
+        import gensim.downloader
+
+        from nlpiper.transformers.embeddings import GensimEmbeddings
+        from nlpiper.core.document import Document
+        from nlpiper.transformers.tokenizers import BasicTokenizer
+
+        glove_vectors = gensim.downloader.load('glove-twitter-25')
+        doc = Document('Test random stuff.')
+
+        t = BasicTokenizer()
+        t(doc, inplace=True)
+
+        e = GensimEmbeddings(glove_vectors, True)
+
+    """
 
     def __init__(self, keyed_vectors: Any, apply_doc: str = 'mean'):
-        """Stem tokens.
-
-        Gensim Embedding extraction.
+        """ Gensim Embedding extraction.
 
         Args:
             keyed_vectors (Any): Gensim model based on keyedVectors,
-            see more in: https://radimrehurek.com/gensim/models/keyedvectors.html
+                see more in: https://radimrehurek.com/gensim/models/keyedvectors.html
             apply_doc (str): Mode to calculate the embeddings vector for the document,
-            which could be `"mean"` or `"sum"` of the tokens.
+                which could be `"mean"` or `"sum"` of the tokens.
         """
         super().__init__(keyed_vectors=keyed_vectors, apply_doc=apply_doc)
         assert apply_doc in ('sum', 'mean'), 'apply_doc value is not valid, can only be: `"mean"` or `"sum"`.'
@@ -76,5 +105,94 @@ class GensimEmbeddings(BaseTransformer):
 
         d.embedded = (getattr(self.np, self.apply_doc)([token.embedded for token in d.tokens], axis=0)
                       if len(d.tokens) != 0 else self.np.zeros(self.keyed_vectors.vector_size))
+
+        return None if inplace else d
+
+
+class TorchTextEmbeddings(BaseTransformer):
+    """Torch Embeddings extraction.
+
+    Callable arguments:
+
+    Args:
+        vectors (Any): Torchtext embedding model. Available models: [`Glove`, `CharNGram`, `FastText`].
+            Check further info here: https://pytorch.org/text/stable/vocab.html#pretrained-word-embeddings
+        apply_doc (str): Mode to calculate the embeddings vector for the document,
+            which could be `"mean"` or `"sum"` of the tokens.
+
+    Returns: Document
+
+     Example:
+
+        from torchtext.vocab import CharNGram
+
+        from nlpiper.transformers.embeddings import TorchTextEmbeddings
+        from nlpiper.core.document import Document
+        from nlpiper.transformers.tokenizers import BasicTokenizer
+
+        doc = Document('Test random stuff.')
+
+        t = BasicTokenizer()
+        t(doc, inplace=True)
+
+        model = CharNGram()
+        e = TorchTextEmbeddings(model, True)
+
+    """
+
+    def __init__(self, model: Any, apply_doc: str = 'mean', **kwargs):
+        """Torch Embeddings extraction.
+
+        Args:
+            vectors (Any): Torchtext embedding model. Available models: [`Glove`, `CharNGram`, `FastText`].
+                Check further info here: https://pytorch.org/text/stable/vocab.html#pretrained-word-embeddings
+            apply_doc (str): Mode to calculate the embeddings vector for the document,
+                which could be `"mean"` or `"sum"` of the tokens.
+
+        """
+        super().__init__(model=model, apply_doc=apply_doc, **kwargs)
+        assert apply_doc in ('sum', 'mean'), 'apply_doc value is not valid, can only be: `"mean"` or `"sum"`.'
+
+        try:
+            import numpy as np
+            self.np = np
+        except ImportError:
+            log.error("To use embeddings please install numpy. "
+                      "See the docs at https://numpy.org/ for more information.")
+            raise
+
+        try:
+            import torchtext
+            assert issubclass(model.__class__, torchtext.vocab.Vectors), 'vectors is not of type `Vectors`'
+            self.model = model
+            self.apply_doc = apply_doc
+
+        except ImportError:
+            log.error("Please install torchtext. "
+                      "See the docs at https://pytorch.org/text/stable/index.html for more information.")
+            raise
+        self.kwargs['vector_size'] = self.model.dim
+
+    @validate(TransformersType.EMBEDDINGS)
+    @add_step
+    def __call__(self, doc: Document, inplace: bool = False) -> Optional[Document]:
+        """Torch Embeddings extraction.
+
+        Args:
+            doc (Document): Document to be normalized.
+            inplace (bool): if False will return a new doc object,
+                            otherwise will change the object passed as parameter.
+
+        Returns: Document
+        """
+        d = doc if inplace else doc._deepcopy()
+
+        for token in d.tokens:
+
+            token.embedded = self.model.get_vecs_by_tokens(
+                token.cleaned).reshape(-1).to('cpu').detach().numpy()
+
+        d.embedded = (getattr(self.np, self.apply_doc)([token.embedded for token in d.tokens], axis=0)
+                      if len(d.tokens) != 0 else self.np.zeros(self.model.dim))
 
         return None if inplace else d

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -26,13 +26,13 @@ class GensimEmbeddings(BaseTransformer):
     Callable arguments:
 
     Args:
-            keyed_vectors (Any): Gensim model based on keyedVectors,
-                see more in: https://radimrehurek.com/gensim/models/keyedvectors.html
-            apply_doc (str): Mode to calculate the embeddings vector for the document,
-                which could be `"mean"` or `"sum"` of the tokens.
+        keyed_vectors (Any): Gensim model based on keyedVectors,
+            see more in: https://radimrehurek.com/gensim/models/keyedvectors.html
+        apply_doc (str): Mode to calculate the embeddings vector for the document,
+            which could be `"mean"` or `"sum"` of the tokens.
 
     Returns:
-                Document with Gensim Embedding or None if `inplace=True`.
+        Document with Gensim Embedding or None if `inplace=True`.
 
     Example:
         >>> import gensim.downloader
@@ -112,7 +112,7 @@ class GensimEmbeddings(BaseTransformer):
 
 
 class TorchTextEmbeddings(BaseTransformer):
-    """Torch Embeddings extraction.
+    """Torchtext Embeddings extraction.
 
     Callable arguments:
 
@@ -122,7 +122,8 @@ class TorchTextEmbeddings(BaseTransformer):
         apply_doc (str): Mode to calculate the embeddings vector for the document,
             which could be `"mean"` or `"sum"` of the tokens.
 
-    Returns: Document
+    Returns:
+        Document with Torchtext Embedding or None if `inplace=True`.
 
      Example:
 
@@ -144,7 +145,7 @@ class TorchTextEmbeddings(BaseTransformer):
     """
 
     def __init__(self, model: Any, apply_doc: str = 'mean', **kwargs):
-        """Torch Embeddings extraction.
+        """Torchtext Embeddings extraction.
 
         Args:
             model (Any): Torchtext embedding model. Available models: [`Glove`, `CharNGram`, `FastText`].
@@ -179,7 +180,7 @@ class TorchTextEmbeddings(BaseTransformer):
     @validate(TransformersType.EMBEDDINGS)
     @add_step
     def __call__(self, doc: Document, inplace: bool = False) -> Optional[Document]:
-        """Torch Embeddings extraction.
+        """Torchtext Embeddings extraction.
 
         Args:
             doc (Document): Document to be normalized.

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -26,10 +26,9 @@ class GensimEmbeddings(BaseTransformer):
     Callable arguments:
 
     Args:
-        keyed_vectors (Any): Gensim model based on keyedVectors,
-            see more in: https://radimrehurek.com/gensim/models/keyedvectors.html
-        apply_doc (str): Mode to calculate the embeddings vector for the document,
-            which could be `"mean"` or `"sum"` of the tokens.
+        doc (Document): Document to be normalized.
+        inplace (bool): if False will return a new doc object,
+            otherwise will change the object passed as parameter.
 
     Returns:
         Document with Gensim Embedding or None if `inplace=True`.
@@ -116,11 +115,10 @@ class TorchTextEmbeddings(BaseTransformer):
 
     Callable arguments:
 
-    Args:
-        model (Any): Torchtext embedding model. Available models: [`Glove`, `CharNGram`, `FastText`].
-            Check further info here: https://pytorch.org/text/stable/vocab.html#pretrained-word-embeddings
-        apply_doc (str): Mode to calculate the embeddings vector for the document,
-            which could be `"mean"` or `"sum"` of the tokens.
+     Args:
+        doc (Document): Document to be normalized.
+        inplace (bool): if False will return a new doc object,
+            otherwise will change the object passed as parameter.
 
     Returns:
         Document with Torchtext Embedding or None if `inplace=True`.
@@ -185,7 +183,7 @@ class TorchTextEmbeddings(BaseTransformer):
         Args:
             doc (Document): Document to be normalized.
             inplace (bool): if False will return a new doc object,
-                            otherwise will change the object passed as parameter.
+                otherwise will change the object passed as parameter.
 
         Returns: Document
         """

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -31,7 +31,8 @@ class GensimEmbeddings(BaseTransformer):
             apply_doc (str): Mode to calculate the embeddings vector for the document,
                 which could be `"mean"` or `"sum"` of the tokens.
 
-    Returns: Document
+    Returns:
+                Document with Gensim Embedding or None if `inplace=True`.
 
     Example:
         >>> import gensim.downloader

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -26,7 +26,7 @@ class GensimEmbeddings(BaseTransformer):
     Callable arguments:
 
     Args:
-        doc (Document): Document to be normalized.
+        doc (Document): Document to extract embeddings.
         inplace (bool): if False will return a new doc object,
             otherwise will change the object passed as parameter.
 

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -116,7 +116,7 @@ class TorchTextEmbeddings(BaseTransformer):
     Callable arguments:
 
      Args:
-        doc (Document): Document to be normalized.
+        doc (Document): Document to extract embeddings.
         inplace (bool): if False will return a new doc object,
             otherwise will change the object passed as parameter.
 

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -47,6 +47,7 @@ class GensimEmbeddings(BaseTransformer):
         t(doc, inplace=True)
 
         e = GensimEmbeddings(glove_vectors, True)
+        e(doc)
 
     """
 
@@ -115,7 +116,7 @@ class TorchTextEmbeddings(BaseTransformer):
     Callable arguments:
 
     Args:
-        vectors (Any): Torchtext embedding model. Available models: [`Glove`, `CharNGram`, `FastText`].
+        model (Any): Torchtext embedding model. Available models: [`Glove`, `CharNGram`, `FastText`].
             Check further info here: https://pytorch.org/text/stable/vocab.html#pretrained-word-embeddings
         apply_doc (str): Mode to calculate the embeddings vector for the document,
             which could be `"mean"` or `"sum"` of the tokens.
@@ -137,6 +138,7 @@ class TorchTextEmbeddings(BaseTransformer):
 
         model = CharNGram()
         e = TorchTextEmbeddings(model, True)
+        e(doc)
 
     """
 
@@ -144,7 +146,7 @@ class TorchTextEmbeddings(BaseTransformer):
         """Torch Embeddings extraction.
 
         Args:
-            vectors (Any): Torchtext embedding model. Available models: [`Glove`, `CharNGram`, `FastText`].
+            model (Any): Torchtext embedding model. Available models: [`Glove`, `CharNGram`, `FastText`].
                 Check further info here: https://pytorch.org/text/stable/vocab.html#pretrained-word-embeddings
             apply_doc (str): Mode to calculate the embeddings vector for the document,
                 which could be `"mean"` or `"sum"` of the tokens.

--- a/nlpiper/transformers/embeddings.py
+++ b/nlpiper/transformers/embeddings.py
@@ -190,11 +190,11 @@ class TorchTextEmbeddings(BaseTransformer):
         d = doc if inplace else doc._deepcopy()
 
         for token in d.tokens:
-            token.embedded = self.model \ 
+            token.embedded = self.model \
                 .get_vecs_by_tokens(token.cleaned) \
-                .reshape(-1) \ 
-                .to('cpu') \ 
-                .detach() \ 
+                .reshape(-1) \
+                .to('cpu') \
+                .detach() \
                 .numpy()
 
         d.embedded = (getattr(self.np, self.apply_doc)([token.embedded for token in d.tokens], axis=0)

--- a/poetry.lock
+++ b/poetry.lock
@@ -152,7 +152,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "emoji"
-version = "1.6.3"
+version = "1.7.0"
 description = "Emoji for Python"
 category = "main"
 optional = true
@@ -311,7 +311,7 @@ twitter = ["twython"]
 
 [[package]]
 name = "numpy"
-version = "1.22.2"
+version = "1.22.3"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = true
@@ -475,11 +475,11 @@ python-versions = "*"
 
 [[package]]
 name = "regex"
-version = "2022.1.18"
+version = "2022.3.2"
 description = "Alternative regular expression module, to replace re."
 category = "main"
 optional = true
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
@@ -714,14 +714,28 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "torch"
-version = "1.10.2"
+version = "1.11.0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 category = "main"
 optional = true
-python-versions = ">=3.6.2"
+python-versions = ">=3.7.0"
 
 [package.dependencies]
 typing-extensions = "*"
+
+[[package]]
+name = "torchtext"
+version = "0.12.0"
+description = "Text utilities and datasets for PyTorch"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = "*"
+requests = "*"
+torch = "*"
+tqdm = "*"
 
 [[package]]
 name = "tqdm"
@@ -769,7 +783,7 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [extras]
-all = ["bs4", "cyhunspell", "nltk", "sacremoses", "stanza", "gensim", "numpy"]
+all = ["bs4", "cyhunspell", "nltk", "sacremoses", "stanza", "gensim", "numpy", "torchtext"]
 bs4 = ["bs4"]
 gensim = ["gensim"]
 hunspell = ["cyhunspell"]
@@ -777,11 +791,12 @@ nltk = ["nltk"]
 numpy = ["numpy"]
 sacremoses = ["sacremoses"]
 stanza = ["stanza"]
+torchtext = ["torchtext"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d2097cf97249ef7a38d34955303f470491e5d0567bd4cc99d19ae719f12d37a4"
+content-hash = "4f5e6d88e21cf02f8f5ec6d89d5596379e32db29dc359d36f200b30f77d64a44"
 
 [metadata.files]
 alabaster = [
@@ -897,7 +912,7 @@ docutils = [
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
 emoji = [
-    {file = "emoji-1.6.3.tar.gz", hash = "sha256:cc28bdc1010b1c03c241f69c7af1e8715144ef45a273bfadc14dc89319ba26d0"},
+    {file = "emoji-1.7.0.tar.gz", hash = "sha256:65c54533ea3c78f30d0729288998715f418d7467de89ec258a31c0ce8660a1d1"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -1024,25 +1039,25 @@ nltk = [
     {file = "nltk-3.7.zip", hash = "sha256:d6507d6460cec76d70afea4242a226a7542f85c669177b9c7f562b7cf1b05502"},
 ]
 numpy = [
-    {file = "numpy-1.22.2-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:515a8b6edbb904594685da6e176ac9fbea8f73a5ebae947281de6613e27f1956"},
-    {file = "numpy-1.22.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:76a4f9bce0278becc2da7da3b8ef854bed41a991f4226911a24a9711baad672c"},
-    {file = "numpy-1.22.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:168259b1b184aa83a514f307352c25c56af111c269ffc109d9704e81f72e764b"},
-    {file = "numpy-1.22.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3556c5550de40027d3121ebbb170f61bbe19eb639c7ad0c7b482cd9b560cd23b"},
-    {file = "numpy-1.22.2-cp310-cp310-win_amd64.whl", hash = "sha256:aafa46b5a39a27aca566198d3312fb3bde95ce9677085efd02c86f7ef6be4ec7"},
-    {file = "numpy-1.22.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:55535c7c2f61e2b2fc817c5cbe1af7cb907c7f011e46ae0a52caa4be1f19afe2"},
-    {file = "numpy-1.22.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:60cb8e5933193a3cc2912ee29ca331e9c15b2da034f76159b7abc520b3d1233a"},
-    {file = "numpy-1.22.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b536b6840e84c1c6a410f3a5aa727821e6108f3454d81a5cd5900999ef04f89"},
-    {file = "numpy-1.22.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2638389562bda1635b564490d76713695ff497242a83d9b684d27bb4a6cc9d7a"},
-    {file = "numpy-1.22.2-cp38-cp38-win32.whl", hash = "sha256:6767ad399e9327bfdbaa40871be4254d1995f4a3ca3806127f10cec778bd9896"},
-    {file = "numpy-1.22.2-cp38-cp38-win_amd64.whl", hash = "sha256:03ae5850619abb34a879d5f2d4bb4dcd025d6d8fb72f5e461dae84edccfe129f"},
-    {file = "numpy-1.22.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:d76a26c5118c4d96e264acc9e3242d72e1a2b92e739807b3b69d8d47684b6677"},
-    {file = "numpy-1.22.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:15efb7b93806d438e3bc590ca8ef2f953b0ce4f86f337ef4559d31ec6cf9d7dd"},
-    {file = "numpy-1.22.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:badca914580eb46385e7f7e4e426fea6de0a37b9e06bec252e481ae7ec287082"},
-    {file = "numpy-1.22.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94dd11d9f13ea1be17bac39c1942f527cbf7065f94953cf62dfe805653da2f8f"},
-    {file = "numpy-1.22.2-cp39-cp39-win32.whl", hash = "sha256:8cf33634b60c9cef346663a222d9841d3bbbc0a2f00221d6bcfd0d993d5543f6"},
-    {file = "numpy-1.22.2-cp39-cp39-win_amd64.whl", hash = "sha256:59153979d60f5bfe9e4c00e401e24dfe0469ef8da6d68247439d3278f30a180f"},
-    {file = "numpy-1.22.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a176959b6e7e00b5a0d6f549a479f869829bfd8150282c590deee6d099bbb6e"},
-    {file = "numpy-1.22.2.zip", hash = "sha256:076aee5a3763d41da6bef9565fdf3cb987606f567cd8b104aded2b38b7b47abf"},
+    {file = "numpy-1.22.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75"},
+    {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
+    {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:568dfd16224abddafb1cbcce2ff14f522abe037268514dd7e42c6776a1c3f8e5"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ca688e1b9b95d80250bca34b11a05e389b1420d00e87a0d12dc45f131f704a1"},
+    {file = "numpy-1.22.3-cp38-cp38-win32.whl", hash = "sha256:e7927a589df200c5e23c57970bafbd0cd322459aa7b1ff73b7c2e84d6e3eae62"},
+    {file = "numpy-1.22.3-cp38-cp38-win_amd64.whl", hash = "sha256:07a8c89a04997625236c5ecb7afe35a02af3896c8aa01890a849913a2309c676"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:2c10a93606e0b4b95c9b04b77dc349b398fdfbda382d2a39ba5a822f669a0123"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fade0d4f4d292b6f39951b6836d7a3c7ef5b2347f3c420cd9820a1d90d794802"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bfb1bb598e8229c2d5d48db1860bcf4311337864ea3efdbe1171fb0c5da515d"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97098b95aa4e418529099c26558eeb8486e66bd1e53a6b606d684d0c3616b168"},
+    {file = "numpy-1.22.3-cp39-cp39-win32.whl", hash = "sha256:fdf3c08bce27132395d3c3ba1503cac12e17282358cb4bddc25cc46b0aca07aa"},
+    {file = "numpy-1.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:639b54cdf6aa4f82fe37ebf70401bbb74b8508fddcf4797f9fe59615b8c5813a"},
+    {file = "numpy-1.22.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c34ea7e9d13a70bf2ab64a2532fe149a9aced424cd05a2c4ba662fd989e3e45f"},
+    {file = "numpy-1.22.3.zip", hash = "sha256:dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -1092,11 +1107,6 @@ psutil = [
     {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2"},
     {file = "psutil-5.9.0-cp310-cp310-win32.whl", hash = "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d"},
     {file = "psutil-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b"},
-    {file = "psutil-5.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9805fed4f2a81de98ae5fe38b75a74c6e6ad2df8a5c479594c7629a1fe35f56"},
-    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c51f1af02334e4b516ec221ee26b8fdf105032418ca5a5ab9737e8c87dafe203"},
-    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32acf55cb9a8cbfb29167cd005951df81b567099295291bcfd1027365b36591d"},
-    {file = "psutil-5.9.0-cp36-cp36m-win32.whl", hash = "sha256:e5c783d0b1ad6ca8a5d3e7b680468c9c926b804be83a3a8e95141b05c39c9f64"},
-    {file = "psutil-5.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:d62a2796e08dd024b8179bd441cb714e0f81226c352c802fca0fd3f89eeacd94"},
     {file = "psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5"},
@@ -1188,80 +1198,80 @@ pytz = [
     {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
 regex = [
-    {file = "regex-2022.1.18-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34316bf693b1d2d29c087ee7e4bb10cdfa39da5f9c50fa15b07489b4ab93a1b5"},
-    {file = "regex-2022.1.18-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a0b9f6a1a15d494b35f25ed07abda03209fa76c33564c09c9e81d34f4b919d7"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f99112aed4fb7cee00c7f77e8b964a9b10f69488cdff626ffd797d02e2e4484f"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a2bf98ac92f58777c0fafc772bf0493e67fcf677302e0c0a630ee517a43b949"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8618d9213a863c468a865e9d2ec50221015f7abf52221bc927152ef26c484b4c"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b52cc45e71657bc4743a5606d9023459de929b2a198d545868e11898ba1c3f59"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e12949e5071c20ec49ef00c75121ed2b076972132fc1913ddf5f76cae8d10b4"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b02e3e72665cd02afafb933453b0c9f6c59ff6e3708bd28d0d8580450e7e88af"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:abfcb0ef78df0ee9df4ea81f03beea41849340ce33a4c4bd4dbb99e23ec781b6"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6213713ac743b190ecbf3f316d6e41d099e774812d470422b3a0f137ea635832"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:61ebbcd208d78658b09e19c78920f1ad38936a0aa0f9c459c46c197d11c580a0"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:b013f759cd69cb0a62de954d6d2096d648bc210034b79b1881406b07ed0a83f9"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9187500d83fd0cef4669385cbb0961e227a41c0c9bc39219044e35810793edf7"},
-    {file = "regex-2022.1.18-cp310-cp310-win32.whl", hash = "sha256:94c623c331a48a5ccc7d25271399aff29729fa202c737ae3b4b28b89d2b0976d"},
-    {file = "regex-2022.1.18-cp310-cp310-win_amd64.whl", hash = "sha256:1a171eaac36a08964d023eeff740b18a415f79aeb212169080c170ec42dd5184"},
-    {file = "regex-2022.1.18-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:49810f907dfe6de8da5da7d2b238d343e6add62f01a15d03e2195afc180059ed"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d2f5c3f7057530afd7b739ed42eb04f1011203bc5e4663e1e1d01bb50f813e3"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:85ffd6b1cb0dfb037ede50ff3bef80d9bf7fa60515d192403af6745524524f3b"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba37f11e1d020969e8a779c06b4af866ffb6b854d7229db63c5fdddfceaa917f"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e27ea1ebe4a561db75a880ac659ff439dec7f55588212e71700bb1ddd5af9"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:37978254d9d00cda01acc1997513f786b6b971e57b778fbe7c20e30ae81a97f3"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e54a1eb9fd38f2779e973d2f8958fd575b532fe26013405d1afb9ee2374e7ab8"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:768632fd8172ae03852e3245f11c8a425d95f65ff444ce46b3e673ae5b057b74"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:de2923886b5d3214be951bc2ce3f6b8ac0d6dfd4a0d0e2a4d2e5523d8046fdfb"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:1333b3ce73269f986b1fa4d5d395643810074dc2de5b9d262eb258daf37dc98f"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:d19a34f8a3429bd536996ad53597b805c10352a8561d8382e05830df389d2b43"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d2f355a951f60f0843f2368b39970e4667517e54e86b1508e76f92b44811a8a"},
-    {file = "regex-2022.1.18-cp36-cp36m-win32.whl", hash = "sha256:2245441445099411b528379dee83e56eadf449db924648e5feb9b747473f42e3"},
-    {file = "regex-2022.1.18-cp36-cp36m-win_amd64.whl", hash = "sha256:25716aa70a0d153cd844fe861d4f3315a6ccafce22b39d8aadbf7fcadff2b633"},
-    {file = "regex-2022.1.18-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7e070d3aef50ac3856f2ef5ec7214798453da878bb5e5a16c16a61edf1817cc3"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22709d701e7037e64dae2a04855021b62efd64a66c3ceed99dfd684bfef09e38"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9099bf89078675c372339011ccfc9ec310310bf6c292b413c013eb90ffdcafc"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04611cc0f627fc4a50bc4a9a2e6178a974c6a6a4aa9c1cca921635d2c47b9c87"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:552a39987ac6655dad4bf6f17dd2b55c7b0c6e949d933b8846d2e312ee80005a"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e031899cb2bc92c0cf4d45389eff5b078d1936860a1be3aa8c94fa25fb46ed8"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2dacb3dae6b8cc579637a7b72f008bff50a94cde5e36e432352f4ca57b9e54c4"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:e5c31d70a478b0ca22a9d2d76d520ae996214019d39ed7dd93af872c7f301e52"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bb804c7d0bfbd7e3f33924ff49757de9106c44e27979e2492819c16972ec0da2"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:36b2d700a27e168fa96272b42d28c7ac3ff72030c67b32f37c05616ebd22a202"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:16f81025bb3556eccb0681d7946e2b35ff254f9f888cff7d2120e8826330315c"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:da80047524eac2acf7c04c18ac7a7da05a9136241f642dd2ed94269ef0d0a45a"},
-    {file = "regex-2022.1.18-cp37-cp37m-win32.whl", hash = "sha256:6ca45359d7a21644793de0e29de497ef7f1ae7268e346c4faf87b421fea364e6"},
-    {file = "regex-2022.1.18-cp37-cp37m-win_amd64.whl", hash = "sha256:38289f1690a7e27aacd049e420769b996826f3728756859420eeee21cc857118"},
-    {file = "regex-2022.1.18-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6014038f52b4b2ac1fa41a58d439a8a00f015b5c0735a0cd4b09afe344c94899"},
-    {file = "regex-2022.1.18-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0b5d6f9aed3153487252d00a18e53f19b7f52a1651bc1d0c4b5844bc286dfa52"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9d24b03daf7415f78abc2d25a208f234e2c585e5e6f92f0204d2ab7b9ab48e3"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bf594cc7cc9d528338d66674c10a5b25e3cde7dd75c3e96784df8f371d77a298"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fd914db437ec25bfa410f8aa0aa2f3ba87cdfc04d9919d608d02330947afaeab"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90b6840b6448203228a9d8464a7a0d99aa8fa9f027ef95fe230579abaf8a6ee1"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11772be1eb1748e0e197a40ffb82fb8fd0d6914cd147d841d9703e2bef24d288"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a602bdc8607c99eb5b391592d58c92618dcd1537fdd87df1813f03fed49957a6"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:7e26eac9e52e8ce86f915fd33380f1b6896a2b51994e40bb094841e5003429b4"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:519c0b3a6fbb68afaa0febf0d28f6c4b0a1074aefc484802ecb9709faf181607"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3c7ea86b9ca83e30fa4d4cd0eaf01db3ebcc7b2726a25990966627e39577d729"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:51f02ca184518702975b56affde6c573ebad4e411599005ce4468b1014b4786c"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:385ccf6d011b97768a640e9d4de25412204fbe8d6b9ae39ff115d4ff03f6fe5d"},
-    {file = "regex-2022.1.18-cp38-cp38-win32.whl", hash = "sha256:1f8c0ae0a0de4e19fddaaff036f508db175f6f03db318c80bbc239a1def62d02"},
-    {file = "regex-2022.1.18-cp38-cp38-win_amd64.whl", hash = "sha256:760c54ad1b8a9b81951030a7e8e7c3ec0964c1cb9fee585a03ff53d9e531bb8e"},
-    {file = "regex-2022.1.18-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:93c20777a72cae8620203ac11c4010365706062aa13aaedd1a21bb07adbb9d5d"},
-    {file = "regex-2022.1.18-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6aa427c55a0abec450bca10b64446331b5ca8f79b648531138f357569705bc4a"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c38baee6bdb7fe1b110b6b3aaa555e6e872d322206b7245aa39572d3fc991ee4"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:752e7ddfb743344d447367baa85bccd3629c2c3940f70506eb5f01abce98ee68"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8acef4d8a4353f6678fd1035422a937c2170de58a2b29f7da045d5249e934101"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c73d2166e4b210b73d1429c4f1ca97cea9cc090e5302df2a7a0a96ce55373f1c"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:24c89346734a4e4d60ecf9b27cac4c1fee3431a413f7aa00be7c4d7bbacc2c4d"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:596f5ae2eeddb79b595583c2e0285312b2783b0ec759930c272dbf02f851ff75"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ecfe51abf7f045e0b9cdde71ca9e153d11238679ef7b5da6c82093874adf3338"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1d6301f5288e9bdca65fab3de6b7de17362c5016d6bf8ee4ba4cbe833b2eda0f"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:93cce7d422a0093cfb3606beae38a8e47a25232eea0f292c878af580a9dc7605"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cf0db26a1f76aa6b3aa314a74b8facd586b7a5457d05b64f8082a62c9c49582a"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:defa0652696ff0ba48c8aff5a1fac1eef1ca6ac9c660b047fc8e7623c4eb5093"},
-    {file = "regex-2022.1.18-cp39-cp39-win32.whl", hash = "sha256:6db1b52c6f2c04fafc8da17ea506608e6be7086715dab498570c3e55e4f8fbd1"},
-    {file = "regex-2022.1.18-cp39-cp39-win_amd64.whl", hash = "sha256:ebaeb93f90c0903233b11ce913a7cb8f6ee069158406e056f884854c737d2442"},
-    {file = "regex-2022.1.18.tar.gz", hash = "sha256:97f32dc03a8054a4c4a5ab5d761ed4861e828b2c200febd4e46857069a483916"},
+    {file = "regex-2022.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ab69b4fe09e296261377d209068d52402fb85ef89dc78a9ac4a29a895f4e24a7"},
+    {file = "regex-2022.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5bc5f921be39ccb65fdda741e04b2555917a4bced24b4df14eddc7569be3b493"},
+    {file = "regex-2022.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43eba5c46208deedec833663201752e865feddc840433285fbadee07b84b464d"},
+    {file = "regex-2022.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c68d2c04f7701a418ec2e5631b7f3552efc32f6bcc1739369c6eeb1af55f62e0"},
+    {file = "regex-2022.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:caa2734ada16a44ae57b229d45091f06e30a9a52ace76d7574546ab23008c635"},
+    {file = "regex-2022.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef806f684f17dbd6263d72a54ad4073af42b42effa3eb42b877e750c24c76f86"},
+    {file = "regex-2022.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be319f4eb400ee567b722e9ea63d5b2bb31464e3cf1b016502e3ee2de4f86f5c"},
+    {file = "regex-2022.3.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:42bb37e2b2d25d958c25903f6125a41aaaa1ed49ca62c103331f24b8a459142f"},
+    {file = "regex-2022.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:fbc88d3ba402b5d041d204ec2449c4078898f89c4a6e6f0ed1c1a510ef1e221d"},
+    {file = "regex-2022.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:91e0f7e7be77250b808a5f46d90bf0032527d3c032b2131b63dee54753a4d729"},
+    {file = "regex-2022.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:cb3652bbe6720786b9137862205986f3ae54a09dec8499a995ed58292bdf77c2"},
+    {file = "regex-2022.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:878c626cbca3b649e14e972c14539a01191d79e58934e3f3ef4a9e17f90277f8"},
+    {file = "regex-2022.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6df070a986fc064d865c381aecf0aaff914178fdf6874da2f2387e82d93cc5bd"},
+    {file = "regex-2022.3.2-cp310-cp310-win32.whl", hash = "sha256:b549d851f91a4efb3e65498bd4249b1447ab6035a9972f7fc215eb1f59328834"},
+    {file = "regex-2022.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:8babb2b5751105dc0aef2a2e539f4ba391e738c62038d8cb331c710f6b0f3da7"},
+    {file = "regex-2022.3.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1977bb64264815d3ef016625adc9df90e6d0e27e76260280c63eca993e3f455f"},
+    {file = "regex-2022.3.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e73652057473ad3e6934944af090852a02590c349357b79182c1b681da2c772"},
+    {file = "regex-2022.3.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b22ff939a8856a44f4822da38ef4868bd3a9ade22bb6d9062b36957c850e404f"},
+    {file = "regex-2022.3.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:878f5d649ba1db9f52cc4ef491f7dba2d061cdc48dd444c54260eebc0b1729b9"},
+    {file = "regex-2022.3.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0008650041531d0eadecc96a73d37c2dc4821cf51b0766e374cb4f1ddc4e1c14"},
+    {file = "regex-2022.3.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:06b1df01cf2aef3a9790858af524ae2588762c8a90e784ba00d003f045306204"},
+    {file = "regex-2022.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57484d39447f94967e83e56db1b1108c68918c44ab519b8ecfc34b790ca52bf7"},
+    {file = "regex-2022.3.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:74d86e8924835f863c34e646392ef39039405f6ce52956d8af16497af4064a30"},
+    {file = "regex-2022.3.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:ae17fc8103f3b63345709d3e9654a274eee1c6072592aec32b026efd401931d0"},
+    {file = "regex-2022.3.2-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:5f92a7cdc6a0ae2abd184e8dfd6ef2279989d24c85d2c85d0423206284103ede"},
+    {file = "regex-2022.3.2-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:5dcc4168536c8f68654f014a3db49b6b4a26b226f735708be2054314ed4964f4"},
+    {file = "regex-2022.3.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:1e30762ddddb22f7f14c4f59c34d3addabc789216d813b0f3e2788d7bcf0cf29"},
+    {file = "regex-2022.3.2-cp36-cp36m-win32.whl", hash = "sha256:286ff9ec2709d56ae7517040be0d6c502642517ce9937ab6d89b1e7d0904f863"},
+    {file = "regex-2022.3.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d326ff80ed531bf2507cba93011c30fff2dd51454c85f55df0f59f2030b1687b"},
+    {file = "regex-2022.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9d828c5987d543d052b53c579a01a52d96b86f937b1777bbfe11ef2728929357"},
+    {file = "regex-2022.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c87ac58b9baaf50b6c1b81a18d20eda7e2883aa9a4fb4f1ca70f2e443bfcdc57"},
+    {file = "regex-2022.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d6c2441538e4fadd4291c8420853431a229fcbefc1bf521810fbc2629d8ae8c2"},
+    {file = "regex-2022.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f3356afbb301ec34a500b8ba8b47cba0b44ed4641c306e1dd981a08b416170b5"},
+    {file = "regex-2022.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d96eec8550fd2fd26f8e675f6d8b61b159482ad8ffa26991b894ed5ee19038b"},
+    {file = "regex-2022.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf668f26604e9f7aee9f8eaae4ca07a948168af90b96be97a4b7fa902a6d2ac1"},
+    {file = "regex-2022.3.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0eb0e2845e81bdea92b8281a3969632686502565abf4a0b9e4ab1471c863d8f3"},
+    {file = "regex-2022.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:87bc01226cd288f0bd9a4f9f07bf6827134dc97a96c22e2d28628e824c8de231"},
+    {file = "regex-2022.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:09b4b6ccc61d4119342b26246ddd5a04accdeebe36bdfe865ad87a0784efd77f"},
+    {file = "regex-2022.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:9557545c10d52c845f270b665b52a6a972884725aa5cf12777374e18f2ea8960"},
+    {file = "regex-2022.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:0be0c34a39e5d04a62fd5342f0886d0e57592a4f4993b3f9d257c1f688b19737"},
+    {file = "regex-2022.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7b103dffb9f6a47ed7ffdf352b78cfe058b1777617371226c1894e1be443afec"},
+    {file = "regex-2022.3.2-cp37-cp37m-win32.whl", hash = "sha256:f8169ec628880bdbca67082a9196e2106060a4a5cbd486ac51881a4df805a36f"},
+    {file = "regex-2022.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:4b9c16a807b17b17c4fa3a1d8c242467237be67ba92ad24ff51425329e7ae3d0"},
+    {file = "regex-2022.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:67250b36edfa714ba62dc62d3f238e86db1065fccb538278804790f578253640"},
+    {file = "regex-2022.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5510932596a0f33399b7fff1bd61c59c977f2b8ee987b36539ba97eb3513584a"},
+    {file = "regex-2022.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6f7ee2289176cb1d2c59a24f50900f8b9580259fa9f1a739432242e7d254f93"},
+    {file = "regex-2022.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86d7a68fa53688e1f612c3246044157117403c7ce19ebab7d02daf45bd63913e"},
+    {file = "regex-2022.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aaf5317c961d93c1a200b9370fb1c6b6836cc7144fef3e5a951326912bf1f5a3"},
+    {file = "regex-2022.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad397bc7d51d69cb07ef89e44243f971a04ce1dca9bf24c992c362406c0c6573"},
+    {file = "regex-2022.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:297c42ede2c81f0cb6f34ea60b5cf6dc965d97fa6936c11fc3286019231f0d66"},
+    {file = "regex-2022.3.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:af4d8cc28e4c7a2f6a9fed544228c567340f8258b6d7ea815b62a72817bbd178"},
+    {file = "regex-2022.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:452519bc4c973e961b1620c815ea6dd8944a12d68e71002be5a7aff0a8361571"},
+    {file = "regex-2022.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cb34c2d66355fb70ae47b5595aafd7218e59bb9c00ad8cc3abd1406ca5874f07"},
+    {file = "regex-2022.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3d146e5591cb67c5e836229a04723a30af795ef9b70a0bbd913572e14b7b940f"},
+    {file = "regex-2022.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:03299b0bcaa7824eb7c0ebd7ef1e3663302d1b533653bfe9dc7e595d453e2ae9"},
+    {file = "regex-2022.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:9ccb0a4ab926016867260c24c192d9df9586e834f5db83dfa2c8fffb3a6e5056"},
+    {file = "regex-2022.3.2-cp38-cp38-win32.whl", hash = "sha256:f7e8f1ee28e0a05831c92dc1c0c1c94af5289963b7cf09eca5b5e3ce4f8c91b0"},
+    {file = "regex-2022.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:35ed2f3c918a00b109157428abfc4e8d1ffabc37c8f9abc5939ebd1e95dabc47"},
+    {file = "regex-2022.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:55820bc631684172b9b56a991d217ec7c2e580d956591dc2144985113980f5a3"},
+    {file = "regex-2022.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:83f03f0bd88c12e63ca2d024adeee75234d69808b341e88343b0232329e1f1a1"},
+    {file = "regex-2022.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42d6007722d46bd2c95cce700181570b56edc0dcbadbfe7855ec26c3f2d7e008"},
+    {file = "regex-2022.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:320c2f4106962ecea0f33d8d31b985d3c185757c49c1fb735501515f963715ed"},
+    {file = "regex-2022.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fbd3fe37353c62fd0eb19fb76f78aa693716262bcd5f9c14bb9e5aca4b3f0dc4"},
+    {file = "regex-2022.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17e51ad1e6131c496b58d317bc9abec71f44eb1957d32629d06013a21bc99cac"},
+    {file = "regex-2022.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72bc3a5effa5974be6d965ed8301ac1e869bc18425c8a8fac179fbe7876e3aee"},
+    {file = "regex-2022.3.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e5602a9b5074dcacc113bba4d2f011d2748f50e3201c8139ac5b68cf2a76bd8b"},
+    {file = "regex-2022.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:729aa8ca624c42f309397c5fc9e21db90bf7e2fdd872461aabdbada33de9063c"},
+    {file = "regex-2022.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d6ecfd1970b3380a569d7b3ecc5dd70dba295897418ed9e31ec3c16a5ab099a5"},
+    {file = "regex-2022.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:13bbf0c9453c6d16e5867bda7f6c0c7cff1decf96c5498318bb87f8136d2abd4"},
+    {file = "regex-2022.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:58ba41e462653eaf68fc4a84ec4d350b26a98d030be1ab24aba1adcc78ffe447"},
+    {file = "regex-2022.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c0446b2871335d5a5e9fcf1462f954586b09a845832263db95059dcd01442015"},
+    {file = "regex-2022.3.2-cp39-cp39-win32.whl", hash = "sha256:20e6a27959f162f979165e496add0d7d56d7038237092d1aba20b46de79158f1"},
+    {file = "regex-2022.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:9efa41d1527b366c88f265a227b20bcec65bda879962e3fc8a2aee11e81266d7"},
+    {file = "regex-2022.3.2.tar.gz", hash = "sha256:79e5af1ff258bc0fe0bdd6f69bc4ae33935a898e3cbefbbccf22e88a27fa053b"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
@@ -1348,25 +1358,46 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 torch = [
-    {file = "torch-1.10.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:8f3fd2e3ffc3bb867133fdf7fbcc8a0bb2e62a5c0696396f51856f5abf9045a8"},
-    {file = "torch-1.10.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:258a0729fb77a3457d5822d84b536057cd119b08049a8d3c41dc3dcdeb48d56e"},
-    {file = "torch-1.10.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:935e5ac804c5093c79f23a7e6ca5b912c166071aa9d8b4a0a3d6a85126d6a47b"},
-    {file = "torch-1.10.2-cp36-cp36m-win_amd64.whl", hash = "sha256:65fd02ed889c63fd82bf1a440c5a94c1310c29f3e6f9f62add416d34da355d97"},
-    {file = "torch-1.10.2-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:6a81f886823bbd15edc2dc0908fa214070df61c9f7ab8831f0a03630275cca5a"},
-    {file = "torch-1.10.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3eee3cf53c1f8fb3f1fe107a22025a8501fc6440d14e09599ba7153002531f84"},
-    {file = "torch-1.10.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ef99b8cca5f9358119b07956915faf6e7906f433ab4a603c160ae9de88918371"},
-    {file = "torch-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:d43bc3f3a2d89ae185ef96d903c935c335219231e57685658648396984e2a67a"},
-    {file = "torch-1.10.2-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:6da1b877880435440a5aa9678ef0f01986d4886416844db1d97ebfb7fd1778d0"},
-    {file = "torch-1.10.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ab77a9f838874f295ed5410c0686fa22547456e0116efb281c66ef5f9d46fe28"},
-    {file = "torch-1.10.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:9ef4c004f9e5168bd1c1930c6aff25fed5b097de81db6271ffbb2e4fb8b89319"},
-    {file = "torch-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:376fc18407add20daa6bbaaffc5a5e06d733abe53bcbd60ef2532bfed34bc091"},
-    {file = "torch-1.10.2-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:f281438ee99bd72ad65c0bba1026a32e45c3b636bc067fc145ad291e9ea2faab"},
-    {file = "torch-1.10.2-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:3592d3dd62b32760c82624e7586222747fe2281240e8653970b35f1d6d4a434c"},
-    {file = "torch-1.10.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fbaf18c1b3e0b31af194a9d853e3739464cf982d279df9d34dd18f1c2a471878"},
-    {file = "torch-1.10.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:97b7b0c667e8b0dd1fc70137a36e0a4841ec10ef850bda60500ad066bef3e2de"},
-    {file = "torch-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:901b52787baeb2e9e1357ca7037da0028bc6ad743f530e0040ae96ef8e27156c"},
-    {file = "torch-1.10.2-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:5b68e9108bd7ebd99eee941686046c517cfaac5331f757bcf440fe02f2e3ced1"},
-    {file = "torch-1.10.2-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:b07ef01e36b716d0d65ca60c4db0ac9d094a0e797d9b55290da4dcda91463b6c"},
+    {file = "torch-1.11.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:62052b50fffc29ca7afc0c04ef8206b6f1ca9d10629cb543077e12967e8d0398"},
+    {file = "torch-1.11.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:866bfba29ac98dec35d893d8e17eaec149d0ac7a53be7baae5c98069897db667"},
+    {file = "torch-1.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:951640fb8db308a59d9b510e7d1ad910aff92913323bbe4bc75435347ddd346d"},
+    {file = "torch-1.11.0-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:5d77b5ece78fdafa5c7f42995ff9474399d22571cd6b2de21a5d666306a2ff8c"},
+    {file = "torch-1.11.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:b5a38682769b544c875ecc34bcb81fbad5c922139b61319aacffcfd8a32f528c"},
+    {file = "torch-1.11.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f82d77695a60626f2b7382d85bc566de8a6b3e50d32080755abc040db802e419"},
+    {file = "torch-1.11.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b96654d42566080a134e784705f33f8536b3b95b5dcde357ed7879b1692a5f78"},
+    {file = "torch-1.11.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8ee7c2e8d7f7020d5bfbc1bb91b9591044c26bbd0cee5e4f694cfd7ed8649260"},
+    {file = "torch-1.11.0-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:6860b1d1bf0bb0b67a6bd47f85a0e4c825b518eea13b5d6101999dbbcbd5bc0c"},
+    {file = "torch-1.11.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4322aa29f50da7f404db06cdf30896ea67b09f673af4a985afc7162bc897864d"},
+    {file = "torch-1.11.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e4d2e0ddd652f30e94cff750220324ec45705d4ecc69658f773b3cb1c7a28dd0"},
+    {file = "torch-1.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:34ce5ea4d8d85da32cdbadb50d4585106901e9f8a3527991daa70c13a09de1f7"},
+    {file = "torch-1.11.0-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:0ccc85cd06227a3edf809e2c795fd5762c3d4e8a38b5c9f744c6e7cf841361bb"},
+    {file = "torch-1.11.0-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:c1554e49d74f1b2c3e7202d77056ba2dd7465437585bac64062b580f714a44e9"},
+    {file = "torch-1.11.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:58c7814502b1c129a650d7092033bbb0bbd64faf1a7941631aaa1aeaddc37570"},
+    {file = "torch-1.11.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:831cf588f01dda9409e75576741d2823453990dee2983d670f2584b37a01adf7"},
+    {file = "torch-1.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:44a1d02fd20f827f0f36dc26fdcfc45e793806a6ad52769a22260655a77a4369"},
+    {file = "torch-1.11.0-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:50fd9bf85c578c871c28f1cb0ace9dfc6024401c7f399b174fb0f370899f4454"},
+    {file = "torch-1.11.0-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:0e48af66ad755f0f9c5f2664028a414f57c49d6adc37e77e06fe0004da4edb61"},
+]
+torchtext = [
+    {file = "torchtext-0.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:66792b1e6d3929944a8d47ad371c71de07a4023f5692385ba7e50c61e111f2f2"},
+    {file = "torchtext-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:af04961985c419579662e703243fa592d74fc44e2863a44c23214b377cf426d8"},
+    {file = "torchtext-0.12.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:174bc6b33d77d9eebbae473f98389183a0c269c68416372ca614b12cfa326969"},
+    {file = "torchtext-0.12.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:36a8c9d6ddbfb70904f15caade91f8deb28b35c2693347853f1bea7f65f00b40"},
+    {file = "torchtext-0.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:391dd25cc426ade637da7297e6d72eaf5efc5fa13a4e25cf2fa5d93119bb176b"},
+    {file = "torchtext-0.12.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:63d9b6e94af6092c472c77e26cf466599eccc1e3a0facc59c87d7611b5afcda6"},
+    {file = "torchtext-0.12.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1db04814d0289429bebd776707ea58d251166f56cc8298956101534a20f0a5cd"},
+    {file = "torchtext-0.12.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:21b6b5a00000ad9dfa09d984a1a7b7cdd79c8310c2a780e672cdf95a2bc26c1b"},
+    {file = "torchtext-0.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:09a047a90615febb5280bb39f69e89de515212d8d0f75b85e5ad474221f1744a"},
+    {file = "torchtext-0.12.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:87530abac557e9702d41edd89c94ccbc4871d43c0f479af97ae3342836e875ec"},
+    {file = "torchtext-0.12.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:bce2a8f6f3a82974b950ee526640b3f747e7bade32b92d0747687bfe76af8d81"},
+    {file = "torchtext-0.12.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:365e5f640e29d2fc924cc274f024ee02e49e680b5a6d10d4d7ccdd1665b73120"},
+    {file = "torchtext-0.12.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2ecd9a32064ea5caf78c7e4843719ecabe100066b32df8d228a6f2ba6bc5ea8b"},
+    {file = "torchtext-0.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:24b34a1b857aeef8d0c6e7b3ed2d9230d0a36df5bdb9dd5262b018675b739306"},
+    {file = "torchtext-0.12.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2ea13e79b02d226adb122ecc8f9648c768e0b683e32fd8b3c0c0c22e8661ed6f"},
+    {file = "torchtext-0.12.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b7fa7557fe5542b58c09abb4bf14e0c6ed6afe653606e318080ba0718d3e1eda"},
+    {file = "torchtext-0.12.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:8bbf5649e4dc691535920437c09017fcab7cfed7125ed0cfe1e1a3bbe792ab93"},
+    {file = "torchtext-0.12.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1845c480fe47c641816d770efac3a32fb927673d46b00c062a2ec377bc312cdc"},
+    {file = "torchtext-0.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:59912472689e5734ccdd134a0352e46bb36cecd3d59b323e097474f4c4e4bf9a"},
 ]
 tqdm = [
     {file = "tqdm-4.63.0-py2.py3-none-any.whl", hash = "sha256:e643e071046f17139dea55b880dc9b33822ce21613b4a4f5ea57f202833dbc29"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ all = [
     "stanza",
     "gensim",
     "numpy",
+    "torchtext"
 ]
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ sacremoses = { version = "^0.0.43", optional = true }
 stanza = { version = "^1.3.0", optional = true }
 gensim = { version = "^4.1.2", optional = true }
 numpy = { version = "^1.22.2", optional = true }
+torchtext = { version = "^0.12.0", optional = true }
 
 [tool.poetry.extras]
 bs4 = ["bs4"]
@@ -51,6 +52,7 @@ hunspell = ["cyhunspell"]
 stanza = ["stanza"]
 gensim = ["gensim"]
 numpy = ["numpy"]
+torchtext = ["torchtext"]
 
 all = [
     "bs4",

--- a/tests/transformers/test_embeddings.py
+++ b/tests/transformers/test_embeddings.py
@@ -1,24 +1,69 @@
 import pytest
 
 from nlpiper.core.document import Document
-from nlpiper.transformers.embeddings import GensimEmbeddings
+from nlpiper.transformers.embeddings import (
+    GensimEmbeddings,
+    TorchTextEmbeddings
+)
 from nlpiper.transformers.tokenizers import BasicTokenizer
 from nlpiper.transformers.normalizers import CaseTokens
 
 
-class TestGensimEmbeddings:
-    pytest.importorskip('gensim')
-    pytest.importorskip('numpy')
-    import gensim.downloader
+def create_gensim_embeddings():
     import numpy as np
-    glove_vectors = gensim.downloader.load('glove-twitter-25')
+    from gensim.models import KeyedVectors
+
+    class Embeddings(KeyedVectors):
+
+        def __init__(self, **kwargs):
+            super().__init__(vector_size=25, **kwargs)
+
+        def __getitem__(self, key):
+            embeddings = {
+                'the': np.array([-1.0167e-02, 2.0194e-02, 2.1473e-01, 1.7289e-01,
+                                -4.3659e-01, -1.4687e-01, 1.8429e+00, -1.5753e-01,
+                                1.8187e-01, -3.1782e-01, 6.8390e-02, 5.1776e-01,
+                                -6.3371e+00, 4.8066e-01, 1.3777e-01, -4.8568e-01,
+                                3.9000e-01, -1.9506e-03, -1.0218e-01, 2.1262e-01,
+                                -8.6146e-01, 1.7263e-01, 1.8783e-01, -8.4250e-01,
+                                -3.1208e-01])
+            }
+            return embeddings[key]
+
+    return Embeddings()
+
+
+def create_embeddings_fasttext_glove(tmpdir):
+    from torchtext.vocab import Vectors
+
+    p = tmpdir.mkdir('.embeddings').join("vectors.txt")
+    p.write("the -0.655379 0.574261 -0.714026 -0.148858 -0.0534275 -1.01101")
+    model = Vectors(name=p.basename, cache=p.dirname)
+    return model
+
+
+def create_embeddings_charngram(tmpdir):
+    from torchtext.vocab import CharNGram
+
+    p = tmpdir.mkdir('.embeddings').join("charNgram_vectors.txt")
+    p.write("3gram-the -0.87907 -0.569777 -0.538168 0.279851 -0.920891 -0.413584")
+    CharNGram.name = p.basename
+    CharNGram.url = None
+    model = CharNGram(cache=p.dirname)
+    return model
+
+
+class TestGensimEmbeddings:
+    pytest.importorskip('numpy')
+    import numpy as np
+    glove_vectors = create_gensim_embeddings()
 
     @pytest.mark.parametrize('apply_doc', ['sum', 'mean'])
     @pytest.mark.parametrize('document', ['Test random stuff.', ''])
     def test_embedding_token(self, apply_doc, document):
         doc = Document(document)
 
-        # To apply a embeddings is necessary to have tokens
+        # To apply a embedding is necessary to have tokens
         t = BasicTokenizer()
         t(doc, inplace=True)
 
@@ -30,7 +75,6 @@ class TestGensimEmbeddings:
         assert out.steps == [repr(t), repr(e)]
         assert out.embedded.shape == (25,)
         assert all([isinstance(token.embedded, self.np.ndarray) for token in out.tokens])
-        assert all([token.embedded is None for token in doc.tokens])
         assert doc.steps == [repr(t)]
         assert doc.embedded is None
 
@@ -47,32 +91,95 @@ class TestGensimEmbeddings:
             GensimEmbeddings(self.glove_vectors, 'random')
 
 
+class TestTorchTextEmbeddings:
+    pytest.importorskip('numpy')
+    import numpy as np
+
+    @pytest.mark.parametrize('apply_doc', ['sum', 'mean'])
+    @pytest.mark.parametrize('document', ['Test random stuff.', ''])
+    @pytest.mark.parametrize('emb_model', [create_embeddings_fasttext_glove, create_embeddings_charngram])
+    def test_embedings_glove_fasttext(self, apply_doc, document, emb_model, tmpdir):
+        doc = Document(document)
+
+        # To apply a embedding is necessary to have tokens
+        t = BasicTokenizer()
+        t(doc, inplace=True)
+
+        model = emb_model(tmpdir)
+
+        e = TorchTextEmbeddings(model, apply_doc)
+
+        # Inplace False
+        out = e(doc)
+
+        assert out.steps == [repr(t), repr(e)]
+        assert out.embedded.shape == (6,)
+        assert all([isinstance(token.embedded, self.np.ndarray) for token in out.tokens])
+        assert doc.steps == [repr(t)]
+        assert doc.embedded is None
+
+        # Inplace True
+        out = e(doc, True)
+
+        assert all([isinstance(token.embedded, self.np.ndarray) for token in doc.tokens])
+        assert doc.steps == [repr(t), repr(e)]
+        assert doc.embedded.shape == (6,)
+        assert out is None
+
+    def test_random_apply_doc(self, tmpdir):
+        model = create_embeddings_fasttext_glove(tmpdir)
+        with pytest.raises(AssertionError):
+            GensimEmbeddings(model, 'random')
+
+
 class TestEmbeddings:
-    pytest.importorskip('hunspell')
     pytest.importorskip('numpy')
     import gensim
 
     @pytest.mark.parametrize('inputs', ["string", 2])
-    def test_with_invalid_input(self, inputs):
+    def test_with_invalid_input_gensim(self, inputs):
+        e = GensimEmbeddings(self.gensim.models.KeyedVectors(1))
         with pytest.raises(TypeError):
-            t = GensimEmbeddings(self.gensim.models.KeyedVectors(1))
+            e(inputs)
+
+    @pytest.mark.parametrize('inputs', ["string", 2])
+    @pytest.mark.parametrize('emb_model', [create_embeddings_fasttext_glove, create_embeddings_charngram])
+    def test_with_invalid_input_torchtext(self, inputs, emb_model, tmpdir):
+        model = emb_model(tmpdir)
+        t = TorchTextEmbeddings(model)
+        with pytest.raises(TypeError):
             t(inputs)
 
-    @pytest.mark.parametrize('inputs', ["test"])
-    def test_without_doc_tokens(self, inputs):
+    def test_without_doc_tokens_gensim(self):
         doc = Document("test")
 
-        t = GensimEmbeddings(self.gensim.models.KeyedVectors(1))
+        e = GensimEmbeddings(self.gensim.models.KeyedVectors(1))
         with pytest.raises(RuntimeError):
-            t(doc)
+            e(doc)
+
+    @pytest.mark.parametrize('emb_model', [create_embeddings_fasttext_glove, create_embeddings_charngram])
+    def test_without_doc_tokens_torchtext(self, emb_model, tmpdir):
+        doc = Document("test")
+
+        model = emb_model(tmpdir)
+        e = TorchTextEmbeddings(model)
+        with pytest.raises(RuntimeError):
+            e(doc)
 
     @pytest.mark.parametrize('hide_available_pkg', ['numpy', 'gensim'], indirect=['hide_available_pkg'])
-    def test_if_no_package(self, hide_available_pkg):  # noqa: F811
+    def test_if_no_package_gensim(self, hide_available_pkg):  # noqa: F811
         with pytest.raises(ModuleNotFoundError):
             GensimEmbeddings(1)
 
+    @pytest.mark.parametrize('hide_available_pkg', ['numpy', 'torchtext'], indirect=['hide_available_pkg'])
+    @pytest.mark.parametrize('emb_model', [create_embeddings_fasttext_glove, create_embeddings_charngram])
+    def test_if_no_package_torchtext(self, emb_model, hide_available_pkg, tmpdir):  # noqa: F811
+        model = emb_model(tmpdir)
+        with pytest.raises(ModuleNotFoundError):
+            TorchTextEmbeddings(model)
+
     @pytest.mark.parametrize('document', ['Test random stuff.', ''])
-    def test_embedding_applied_twice(self, document):
+    def test_embedding_applied_twice_gensim(self, document):
         doc = Document(document)
 
         # To apply a embeddings is necessary to have tokens
@@ -85,7 +192,22 @@ class TestEmbeddings:
             e(e(doc))
 
     @pytest.mark.parametrize('document', ['Test random stuff.', ''])
-    def test_embedding_applied_then_normalizer(self, document):
+    @pytest.mark.parametrize('emb_model', [create_embeddings_fasttext_glove, create_embeddings_charngram])
+    def test_embedding_applied_twice_torchtext(self, document, emb_model, tmpdir):
+        doc = Document(document)
+
+        # To apply a embeddings is necessary to have tokens
+        t = BasicTokenizer()
+        t(doc, inplace=True)
+
+        model = emb_model(tmpdir)
+        e = TorchTextEmbeddings(model)
+
+        with pytest.raises(RuntimeError):
+            e(e(doc))
+
+    @pytest.mark.parametrize('document', ['Test random stuff.', ''])
+    def test_embedding_applied_then_normalizer_gensim(self, document):
         doc = Document(document)
 
         # To apply a embeddings is necessary to have tokens
@@ -94,6 +216,22 @@ class TestEmbeddings:
         t(doc, inplace=True)
 
         e = GensimEmbeddings(self.gensim.models.KeyedVectors(1))
+
+        with pytest.raises(RuntimeError):
+            n(e(doc))
+
+    @pytest.mark.parametrize('document', ['Test random stuff.', ''])
+    @pytest.mark.parametrize('emb_model', [create_embeddings_fasttext_glove, create_embeddings_charngram])
+    def test_embedding_applied_then_normalizer_torchtext(self, document, emb_model, tmpdir):
+        doc = Document(document)
+
+        # To apply a embeddings is necessary to have tokens
+        t = BasicTokenizer()
+        n = CaseTokens()
+        t(doc, inplace=True)
+
+        model = emb_model(tmpdir)
+        e = TorchTextEmbeddings(model)
 
         with pytest.raises(RuntimeError):
             n(e(doc))

--- a/tests/transformers/test_embeddings.py
+++ b/tests/transformers/test_embeddings.py
@@ -93,6 +93,7 @@ class TestGensimEmbeddings:
 
 class TestTorchTextEmbeddings:
     pytest.importorskip('numpy')
+    pytest.importorskip('torchtext')
     import numpy as np
 
     @pytest.mark.parametrize('apply_doc', ['sum', 'mean'])


### PR DESCRIPTION
## :pencil: Changelog:

- :sparkles: Features: 
    - Allow `GensimEmbeddings` to load a small `KeyedVectors` dictionary.
    - Inclusion of `torchtext` embedding models (`GloVe`, `FastText` and `CharNGram`) in `embeddings.py`.

closes #52